### PR TITLE
Add slash command system for custom shortcuts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,10 @@
 Building a web-accessible terminal interface for Claude Code that allows non-technical users to interact with AI coding assistance through a browser.
 
 ## 📊 Current Status
-- **Version**: 1.0.0
+- **Version**: 1.1.0
 - **Last Session**: 2025-07-25
 - **Next Priority**: Test complete system integration
+- **Latest Feature**: Slash command system for custom shortcuts
 
 ## 🔥 Active Tasks (Current Session)
 Working on:
@@ -14,6 +15,7 @@ Working on:
 - [x] Build backend server with Docker integration
 - [x] Implement WebSocket streaming
 - [x] Create frontend with xterm.js
+- [x] Implement slash command system
 - [ ] Test Docker connection and Claude Code integration
 
 ## 📋 Master Task List
@@ -25,6 +27,9 @@ Working on:
 - [x] Build React frontend with TypeScript
 - [x] Integrate xterm.js for terminal emulation
 - [x] Design clean UI for non-technical users
+- [x] Implement slash command system with modal UI (2025-07-25)
+- [x] Add local storage persistence for commands
+- [x] Create command management interface
 
 ### High Priority
 - [ ] Test end-to-end Docker integration
@@ -40,15 +45,22 @@ Working on:
 ## 🏗️ Project Structure
 ```
 claude-web-terminal/
-├── server.js           <-- Backend server (Express + WebSocket)
-├── package.json        <-- Backend dependencies
-├── client/             <-- React frontend
+├── server.js                <-- Backend server (Express + WebSocket)
+├── package.json             <-- Backend dependencies
+├── client/                  <-- React frontend
 │   ├── src/
-│   │   ├── App.tsx    <-- Main terminal interface
-│   │   └── App.css    <-- Styling
+│   │   ├── TerminalApp.tsx  <-- Main terminal interface
+│   │   ├── App.css          <-- Styling
+│   │   ├── components/      <-- UI components
+│   │   │   ├── SlashCommandModal.tsx
+│   │   │   └── SlashCommandList.tsx
+│   │   ├── services/        <-- Business logic
+│   │   │   └── slashCommandService.ts
+│   │   └── types/           <-- TypeScript types
+│   │       └── slashCommand.ts
 │   └── package.json
-├── CLAUDE.md          <-- You are here
-└── README.md          <-- Setup instructions
+├── CLAUDE.md                <-- You are here
+└── README.md                <-- Setup instructions
 ```
 
 ## 💡 Key Architecture Decisions
@@ -78,8 +90,9 @@ claude-web-terminal/
 1. User sees friendly interface with tips
 2. Clicks "Start Session" button
 3. Terminal connects via WebSocket
-4. User types naturally to Claude
-5. Sees streaming responses in real-time
+4. User types naturally to Claude or uses slash commands
+5. Slash commands are intercepted and expanded before sending
+6. Sees streaming responses in real-time
 
 ## ⚡ Quick Commands
 ```bash
@@ -101,6 +114,8 @@ npm start
 - ANTHROPIC_API_KEY must be set in environment
 - WebSocket runs on port 8080, HTTP on 3000
 - Each session gets isolated Docker container
+- Slash commands are stored in browser local storage
+- Example command `/hn` pre-loaded for testing
 
 ## 🔄 Next Session Setup
 1. Verify Docker image: `docker images | grep claude-env`

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A web-accessible terminal interface for Claude Code that makes AI coding assista
 - 🎨 **Friendly UI** - Designed for non-technical users
 - 🔒 **Isolated sessions** - Each user gets their own Docker container
 - 💬 **Natural interaction** - Just type questions like you're chatting
+- ⚡ **Slash Commands** - Create custom shortcuts for frequently used prompts
 
 ## Prerequisites
 
@@ -67,6 +68,43 @@ A web-accessible terminal interface for Claude Code that makes AI coding assista
 3. Backend creates a Docker container with Claude Code
 4. WebSocket streams terminal I/O in real-time
 5. Users can type naturally to interact with Claude
+
+## Slash Commands
+
+Slash commands allow you to create custom shortcuts for frequently used prompts:
+
+### Creating a Slash Command
+
+1. Click "➕ New Command" in the control panel
+2. Enter your shortcut (e.g., `/hn`)
+3. Write the full prompt that should be sent to Claude
+4. Optionally add:
+   - Description for easy identification
+   - Reference files from your workspace
+   - URLs that Claude should use
+
+### Using Slash Commands
+
+Simply type your shortcut in the terminal and press Enter:
+```
+/hn
+```
+
+This will automatically expand to your full prompt and send it to Claude.
+
+### Example Commands
+
+- `/hn` - Fetch latest Hacker News posts
+- `/debug` - Analyze error logs and suggest fixes
+- `/review` - Review code for best practices
+- `/test` - Generate unit tests for current file
+
+### Managing Commands
+
+- Click "📋 View Commands" to see all your saved commands
+- Edit commands by clicking the ✏️ icon
+- Delete commands with the 🗑️ icon
+- Commands are saved locally in your browser
 
 ## Architecture
 

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -77,6 +77,26 @@ body {
   gap: 0.5rem;
 }
 
+.slash-command-controls {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.command-button {
+  padding: 0.5rem 1rem;
+  background-color: #6c757d;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.command-button:hover {
+  background-color: #5a6268;
+}
+
 .terminal-container {
   flex: 1;
   padding: 1.5rem;

--- a/client/src/TerminalApp.tsx
+++ b/client/src/TerminalApp.tsx
@@ -3,6 +3,10 @@ import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import 'xterm/css/xterm.css';
 import './App.css';
+import { slashCommandService } from './services/slashCommandService';
+import { SlashCommandModal } from './components/SlashCommandModal';
+import { SlashCommandList } from './components/SlashCommandList';
+import { SlashCommand } from './types/slashCommand';
 
 function TerminalApp() {
   const terminalRef = useRef<HTMLDivElement>(null);
@@ -12,6 +16,19 @@ function TerminalApp() {
   const [sessionStarted, setSessionStarted] = useState(false);
   const sessionStartedRef = useRef(false);
   const fitAddonRef = useRef<FitAddon | null>(null);
+  const currentLineRef = useRef<string>('');
+  const cursorPositionRef = useRef<number>(0);
+  
+  // Slash command state
+  const [showCommandModal, setShowCommandModal] = useState(false);
+  const [showCommandList, setShowCommandList] = useState(false);
+  const [editingCommand, setEditingCommand] = useState<SlashCommand | undefined>(undefined);
+  const [commands, setCommands] = useState<SlashCommand[]>([]);
+
+  useEffect(() => {
+    // Load saved commands
+    setCommands(slashCommandService.getAllCommands());
+  }, []);
 
   useEffect(() => {
     // Fetch server configuration first
@@ -139,9 +156,57 @@ function TerminalApp() {
 
     setWs(websocket);
 
-    // Terminal input handler
+    // Terminal input handler with slash command interception
     term.onData((data) => {
       if (websocket.readyState === WebSocket.OPEN && sessionStartedRef.current) {
+        // Track current line for slash command detection
+        const code = data.charCodeAt(0);
+        
+        // Handle special characters
+        if (code === 13) { // Enter key
+          const currentLine = currentLineRef.current.trim();
+          
+          // Check if it's a slash command
+          if (currentLine.startsWith('/')) {
+            const expandedCommand = slashCommandService.expandCommand(currentLine);
+            
+            if (expandedCommand) {
+              // Clear the current line in terminal
+              const clearLine = '\r\x1b[K';
+              term.write(clearLine);
+              
+              // Send the expanded command
+              websocket.send(JSON.stringify({
+                type: 'input',
+                data: expandedCommand + '\n'
+              }));
+              
+              // Reset current line
+              currentLineRef.current = '';
+              cursorPositionRef.current = 0;
+              return;
+            }
+          }
+          
+          // Not a slash command or not found, send as normal
+          currentLineRef.current = '';
+          cursorPositionRef.current = 0;
+        } else if (code === 127) { // Backspace
+          if (cursorPositionRef.current > 0) {
+            currentLineRef.current = 
+              currentLineRef.current.slice(0, cursorPositionRef.current - 1) + 
+              currentLineRef.current.slice(cursorPositionRef.current);
+            cursorPositionRef.current--;
+          }
+        } else if (code >= 32) { // Printable characters
+          currentLineRef.current = 
+            currentLineRef.current.slice(0, cursorPositionRef.current) + 
+            data + 
+            currentLineRef.current.slice(cursorPositionRef.current);
+          cursorPositionRef.current += data.length;
+        }
+        
+        // Send the original input to the backend
         websocket.send(JSON.stringify({
           type: 'input',
           data: data
@@ -164,6 +229,34 @@ function TerminalApp() {
     }
   };
 
+  // Slash command handlers
+  const handleCreateCommand = (input: any) => {
+    const newCommand = slashCommandService.createCommand(input);
+    setCommands(slashCommandService.getAllCommands());
+    setShowCommandModal(false);
+    setEditingCommand(undefined);
+  };
+
+  const handleUpdateCommand = (input: any) => {
+    if (editingCommand) {
+      slashCommandService.updateCommand(editingCommand.shortcut, input);
+      setCommands(slashCommandService.getAllCommands());
+      setShowCommandModal(false);
+      setEditingCommand(undefined);
+    }
+  };
+
+  const handleDeleteCommand = (shortcut: string) => {
+    slashCommandService.deleteCommand(shortcut);
+    setCommands(slashCommandService.getAllCommands());
+  };
+
+  const handleEditCommand = (command: SlashCommand) => {
+    setEditingCommand(command);
+    setShowCommandList(false);
+    setShowCommandModal(true);
+  };
+
   return (
     <div className="App">
       <header className="App-header">
@@ -180,6 +273,23 @@ function TerminalApp() {
           {sessionStarted ? '✅ Session Active' : '🚀 Start Session'}
         </button>
         
+        <div className="slash-command-controls">
+          <button
+            onClick={() => setShowCommandModal(true)}
+            className="command-button"
+            title="Create new slash command"
+          >
+            ➕ New Command
+          </button>
+          <button
+            onClick={() => setShowCommandList(true)}
+            className="command-button"
+            title="View all slash commands"
+          >
+            📋 View Commands
+          </button>
+        </div>
+        
         <div className="status">
           Status: {connected ? '🟢 Connected' : '🔴 Disconnected'}
         </div>
@@ -193,6 +303,26 @@ function TerminalApp() {
           style={{ cursor: 'text' }}
         />
       </div>
+
+      {/* Slash Command Modals */}
+      <SlashCommandModal
+        isOpen={showCommandModal}
+        onClose={() => {
+          setShowCommandModal(false);
+          setEditingCommand(undefined);
+        }}
+        onSave={editingCommand ? handleUpdateCommand : handleCreateCommand}
+        editingCommand={editingCommand}
+      />
+
+      {showCommandList && (
+        <SlashCommandList
+          commands={commands}
+          onEdit={handleEditCommand}
+          onDelete={handleDeleteCommand}
+          onClose={() => setShowCommandList(false)}
+        />
+      )}
     </div>
   );
 }

--- a/client/src/components/SlashCommandList.css
+++ b/client/src/components/SlashCommandList.css
@@ -1,0 +1,158 @@
+.command-list-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 999;
+}
+
+.command-list-content {
+  background-color: #1e1e1e;
+  border-radius: 8px;
+  padding: 24px;
+  max-width: 800px;
+  width: 90%;
+  max-height: 80vh;
+  overflow-y: auto;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+}
+
+.command-list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.command-list-header h2 {
+  margin: 0;
+  color: #ffffff;
+  font-size: 24px;
+}
+
+.close-button {
+  background: none;
+  border: none;
+  color: #999999;
+  font-size: 28px;
+  cursor: pointer;
+  padding: 0;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.2s;
+}
+
+.close-button:hover {
+  color: #ffffff;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 40px 20px;
+  color: #999999;
+}
+
+.empty-state p {
+  margin: 8px 0;
+}
+
+.commands-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 16px;
+}
+
+.command-card {
+  background-color: #2d2d2d;
+  border: 1px solid #3e3e3e;
+  border-radius: 6px;
+  padding: 16px;
+  transition: border-color 0.2s;
+}
+
+.command-card:hover {
+  border-color: #4e4e4e;
+}
+
+.command-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.command-header h3 {
+  margin: 0;
+  color: #007acc;
+  font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+  font-size: 16px;
+}
+
+.command-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.edit-button,
+.delete-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 16px;
+  padding: 4px;
+  transition: opacity 0.2s;
+}
+
+.edit-button:hover,
+.delete-button:hover {
+  opacity: 0.7;
+}
+
+.command-description {
+  color: #cccccc;
+  font-size: 14px;
+  margin: 0 0 8px 0;
+}
+
+.command-prompt {
+  background-color: #1e1e1e;
+  border: 1px solid #3e3e3e;
+  border-radius: 4px;
+  padding: 8px;
+  color: #ffffff;
+  font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+  font-size: 13px;
+  margin-bottom: 12px;
+  max-height: 60px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.command-metadata {
+  display: flex;
+  gap: 16px;
+  font-size: 12px;
+  color: #999999;
+}
+
+.metadata-item {
+  display: flex;
+  gap: 4px;
+}
+
+.metadata-label {
+  font-weight: 500;
+}
+
+.metadata-value {
+  color: #cccccc;
+}

--- a/client/src/components/SlashCommandList.tsx
+++ b/client/src/components/SlashCommandList.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { SlashCommand } from '../types/slashCommand';
+import './SlashCommandList.css';
+
+interface SlashCommandListProps {
+  commands: SlashCommand[];
+  onEdit: (command: SlashCommand) => void;
+  onDelete: (shortcut: string) => void;
+  onClose: () => void;
+}
+
+export const SlashCommandList: React.FC<SlashCommandListProps> = ({
+  commands,
+  onEdit,
+  onDelete,
+  onClose
+}) => {
+  return (
+    <div className="command-list-overlay" onClick={onClose}>
+      <div className="command-list-content" onClick={e => e.stopPropagation()}>
+        <div className="command-list-header">
+          <h2>Slash Commands</h2>
+          <button className="close-button" onClick={onClose}>×</button>
+        </div>
+
+        {commands.length === 0 ? (
+          <div className="empty-state">
+            <p>No slash commands created yet.</p>
+            <p>Click "New Command" to create your first one!</p>
+          </div>
+        ) : (
+          <div className="commands-grid">
+            {commands.map(command => (
+              <div key={command.id} className="command-card">
+                <div className="command-header">
+                  <h3>{command.shortcut}</h3>
+                  <div className="command-actions">
+                    <button
+                      className="edit-button"
+                      onClick={() => onEdit(command)}
+                      title="Edit"
+                    >
+                      ✏️
+                    </button>
+                    <button
+                      className="delete-button"
+                      onClick={() => {
+                        if (window.confirm(`Delete ${command.shortcut}?`)) {
+                          onDelete(command.shortcut);
+                        }
+                      }}
+                      title="Delete"
+                    >
+                      🗑️
+                    </button>
+                  </div>
+                </div>
+                
+                {command.description && (
+                  <p className="command-description">{command.description}</p>
+                )}
+                
+                <div className="command-prompt">{command.prompt}</div>
+                
+                <div className="command-metadata">
+                  {command.referenceFiles && command.referenceFiles.length > 0 && (
+                    <div className="metadata-item">
+                      <span className="metadata-label">Files:</span>
+                      <span className="metadata-value">{command.referenceFiles.length}</span>
+                    </div>
+                  )}
+                  {command.urls && command.urls.length > 0 && (
+                    <div className="metadata-item">
+                      <span className="metadata-label">URLs:</span>
+                      <span className="metadata-value">{command.urls.length}</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/client/src/components/SlashCommandModal.css
+++ b/client/src/components/SlashCommandModal.css
@@ -1,0 +1,155 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background-color: #1e1e1e;
+  border-radius: 8px;
+  padding: 24px;
+  max-width: 600px;
+  width: 90%;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+}
+
+.modal-content h2 {
+  margin: 0 0 20px 0;
+  color: #ffffff;
+  font-size: 24px;
+}
+
+.form-group {
+  margin-bottom: 20px;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 8px;
+  color: #cccccc;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.form-input,
+.form-textarea {
+  width: 100%;
+  padding: 10px 12px;
+  background-color: #2d2d2d;
+  border: 1px solid #3e3e3e;
+  border-radius: 4px;
+  color: #ffffff;
+  font-size: 14px;
+  font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+  transition: border-color 0.2s;
+}
+
+.form-input:focus,
+.form-textarea:focus {
+  outline: none;
+  border-color: #007acc;
+}
+
+.form-textarea {
+  resize: vertical;
+  min-height: 100px;
+}
+
+.input-with-button {
+  display: flex;
+  gap: 8px;
+}
+
+.add-button {
+  padding: 10px 16px;
+  background-color: #007acc;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.2s;
+}
+
+.add-button:hover {
+  background-color: #005a9e;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 8px;
+  background-color: #3e3e3e;
+  border-radius: 4px;
+  color: #ffffff;
+  font-size: 13px;
+}
+
+.tag-remove {
+  margin-left: 6px;
+  background: none;
+  border: none;
+  color: #999999;
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  padding: 0;
+  transition: color 0.2s;
+}
+
+.tag-remove:hover {
+  color: #ff6b6b;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 24px;
+  padding-top: 20px;
+  border-top: 1px solid #3e3e3e;
+}
+
+.cancel-button,
+.save-button {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 4px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.cancel-button {
+  background-color: #3e3e3e;
+  color: #ffffff;
+}
+
+.cancel-button:hover {
+  background-color: #4e4e4e;
+}
+
+.save-button {
+  background-color: #007acc;
+  color: #ffffff;
+}
+
+.save-button:hover {
+  background-color: #005a9e;
+}

--- a/client/src/components/SlashCommandModal.tsx
+++ b/client/src/components/SlashCommandModal.tsx
@@ -1,0 +1,194 @@
+import React, { useState, useEffect } from 'react';
+import { SlashCommand, SlashCommandInput } from '../types/slashCommand';
+import './SlashCommandModal.css';
+
+interface SlashCommandModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (command: SlashCommandInput) => void;
+  editingCommand?: SlashCommand;
+}
+
+export const SlashCommandModal: React.FC<SlashCommandModalProps> = ({
+  isOpen,
+  onClose,
+  onSave,
+  editingCommand
+}) => {
+  const [shortcut, setShortcut] = useState('');
+  const [prompt, setPrompt] = useState('');
+  const [description, setDescription] = useState('');
+  const [referenceFiles, setReferenceFiles] = useState<string[]>([]);
+  const [urls, setUrls] = useState<string[]>([]);
+  const [newFile, setNewFile] = useState('');
+  const [newUrl, setNewUrl] = useState('');
+
+  useEffect(() => {
+    if (editingCommand) {
+      setShortcut(editingCommand.shortcut);
+      setPrompt(editingCommand.prompt);
+      setDescription(editingCommand.description || '');
+      setReferenceFiles(editingCommand.referenceFiles || []);
+      setUrls(editingCommand.urls || []);
+    } else {
+      resetForm();
+    }
+  }, [editingCommand]);
+
+  const resetForm = () => {
+    setShortcut('');
+    setPrompt('');
+    setDescription('');
+    setReferenceFiles([]);
+    setUrls([]);
+    setNewFile('');
+    setNewUrl('');
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!shortcut.startsWith('/')) {
+      alert('Shortcut must start with /');
+      return;
+    }
+
+    onSave({
+      shortcut,
+      prompt,
+      description: description || undefined,
+      referenceFiles: referenceFiles.length > 0 ? referenceFiles : undefined,
+      urls: urls.length > 0 ? urls : undefined
+    });
+
+    resetForm();
+    onClose();
+  };
+
+  const addFile = () => {
+    if (newFile && !referenceFiles.includes(newFile)) {
+      setReferenceFiles([...referenceFiles, newFile]);
+      setNewFile('');
+    }
+  };
+
+  const removeFile = (file: string) => {
+    setReferenceFiles(referenceFiles.filter(f => f !== file));
+  };
+
+  const addUrl = () => {
+    if (newUrl && !urls.includes(newUrl)) {
+      setUrls([...urls, newUrl]);
+      setNewUrl('');
+    }
+  };
+
+  const removeUrl = (url: string) => {
+    setUrls(urls.filter(u => u !== url));
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-content" onClick={e => e.stopPropagation()}>
+        <h2>{editingCommand ? 'Edit' : 'Create'} Slash Command</h2>
+        
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label htmlFor="shortcut">Shortcut</label>
+            <input
+              id="shortcut"
+              type="text"
+              value={shortcut}
+              onChange={e => setShortcut(e.target.value)}
+              placeholder="/hn"
+              required
+              className="form-input"
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="prompt">Prompt</label>
+            <textarea
+              id="prompt"
+              value={prompt}
+              onChange={e => setPrompt(e.target.value)}
+              placeholder="Fetch the latest top posts on Hacker News for the last 24 hours..."
+              required
+              rows={4}
+              className="form-textarea"
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="description">Description (optional)</label>
+            <input
+              id="description"
+              type="text"
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+              placeholder="Get latest Hacker News posts"
+              className="form-input"
+            />
+          </div>
+
+          <div className="form-group">
+            <label>Reference Files (optional)</label>
+            <div className="input-with-button">
+              <input
+                type="text"
+                value={newFile}
+                onChange={e => setNewFile(e.target.value)}
+                placeholder="path/to/file.ts"
+                className="form-input"
+                onKeyPress={e => e.key === 'Enter' && (e.preventDefault(), addFile())}
+              />
+              <button type="button" onClick={addFile} className="add-button">Add</button>
+            </div>
+            <div className="tag-list">
+              {referenceFiles.map(file => (
+                <span key={file} className="tag">
+                  {file}
+                  <button type="button" onClick={() => removeFile(file)} className="tag-remove">×</button>
+                </span>
+              ))}
+            </div>
+          </div>
+
+          <div className="form-group">
+            <label>URLs (optional)</label>
+            <div className="input-with-button">
+              <input
+                type="text"
+                value={newUrl}
+                onChange={e => setNewUrl(e.target.value)}
+                placeholder="https://example.com"
+                className="form-input"
+                onKeyPress={e => e.key === 'Enter' && (e.preventDefault(), addUrl())}
+              />
+              <button type="button" onClick={addUrl} className="add-button">Add</button>
+            </div>
+            <div className="tag-list">
+              {urls.map(url => (
+                <span key={url} className="tag">
+                  {url}
+                  <button type="button" onClick={() => removeUrl(url)} className="tag-remove">×</button>
+                </span>
+              ))}
+            </div>
+          </div>
+
+          <div className="modal-actions">
+            <button type="button" onClick={onClose} className="cancel-button">
+              Cancel
+            </button>
+            <button type="submit" className="save-button">
+              {editingCommand ? 'Update' : 'Save'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/client/src/services/slashCommandService.ts
+++ b/client/src/services/slashCommandService.ts
@@ -1,0 +1,130 @@
+import { SlashCommand, SlashCommandInput } from '../types/slashCommand';
+
+const STORAGE_KEY = 'claude-slash-commands';
+
+export class SlashCommandService {
+  private commands: Map<string, SlashCommand> = new Map();
+
+  constructor() {
+    this.loadFromStorage();
+    
+    // Add example command if none exist
+    if (this.commands.size === 0) {
+      this.createCommand({
+        shortcut: '/hn',
+        prompt: 'Fetch the latest top posts on Hacker News for the last 24 hours, return them in a list in markdown format and make sure that the titles are hyperlinked to the destination URL and the comments are linked to the Hacker News thread.',
+        description: 'Get latest Hacker News top posts',
+        urls: ['https://news.ycombinator.com']
+      });
+    }
+  }
+
+  private loadFromStorage(): void {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        const commands: SlashCommand[] = JSON.parse(stored);
+        commands.forEach(cmd => {
+          // Ensure dates are Date objects
+          cmd.createdAt = new Date(cmd.createdAt);
+          cmd.updatedAt = new Date(cmd.updatedAt);
+          this.commands.set(cmd.shortcut, cmd);
+        });
+      } catch (error) {
+        console.error('Failed to load slash commands:', error);
+      }
+    }
+  }
+
+  private saveToStorage(): void {
+    const commands = Array.from(this.commands.values());
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(commands));
+  }
+
+  public createCommand(input: SlashCommandInput): SlashCommand {
+    const now = new Date();
+    const command: SlashCommand = {
+      id: `cmd_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+      ...input,
+      createdAt: now,
+      updatedAt: now
+    };
+
+    this.commands.set(command.shortcut, command);
+    this.saveToStorage();
+    return command;
+  }
+
+  public updateCommand(shortcut: string, input: Partial<SlashCommandInput>): SlashCommand | null {
+    const existing = this.commands.get(shortcut);
+    if (!existing) return null;
+
+    const updated: SlashCommand = {
+      ...existing,
+      ...input,
+      updatedAt: new Date()
+    };
+
+    // If shortcut changed, delete old entry
+    if (input.shortcut && input.shortcut !== shortcut) {
+      this.commands.delete(shortcut);
+    }
+
+    this.commands.set(updated.shortcut, updated);
+    this.saveToStorage();
+    return updated;
+  }
+
+  public deleteCommand(shortcut: string): boolean {
+    const deleted = this.commands.delete(shortcut);
+    if (deleted) {
+      this.saveToStorage();
+    }
+    return deleted;
+  }
+
+  public getCommand(shortcut: string): SlashCommand | undefined {
+    return this.commands.get(shortcut);
+  }
+
+  public getAllCommands(): SlashCommand[] {
+    return Array.from(this.commands.values());
+  }
+
+  public hasCommand(shortcut: string): boolean {
+    return this.commands.has(shortcut);
+  }
+
+  public expandCommand(input: string): string | null {
+    // Check if input starts with a known slash command
+    const parts = input.split(' ');
+    const shortcut = parts[0];
+    
+    const command = this.getCommand(shortcut);
+    if (!command) return null;
+
+    // Build the expanded prompt
+    let expandedPrompt = command.prompt;
+
+    // Add file references if any
+    if (command.referenceFiles && command.referenceFiles.length > 0) {
+      expandedPrompt = `Please reference these files: ${command.referenceFiles.join(', ')}\n\n${expandedPrompt}`;
+    }
+
+    // Add URL references if any
+    if (command.urls && command.urls.length > 0) {
+      expandedPrompt = `${expandedPrompt}\n\nUse these URLs: ${command.urls.join(', ')}`;
+    }
+
+    // If there are additional arguments after the slash command, append them
+    if (parts.length > 1) {
+      const additionalArgs = parts.slice(1).join(' ');
+      expandedPrompt = `${expandedPrompt}\n\nAdditional context: ${additionalArgs}`;
+    }
+
+    return expandedPrompt;
+  }
+}
+
+// Export singleton instance
+export const slashCommandService = new SlashCommandService();

--- a/client/src/types/slashCommand.ts
+++ b/client/src/types/slashCommand.ts
@@ -1,0 +1,18 @@
+export interface SlashCommand {
+  id: string;
+  shortcut: string; // e.g., "/hn"
+  prompt: string;   // The full prompt to send to Claude
+  description?: string;
+  referenceFiles?: string[]; // Workspace files to reference
+  urls?: string[]; // URLs to include in the prompt
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface SlashCommandInput {
+  shortcut: string;
+  prompt: string;
+  description?: string;
+  referenceFiles?: string[];
+  urls?: string[];
+}


### PR DESCRIPTION
## Summary
- Implemented a custom slash command system that allows users to create shortcuts for frequently used prompts
- Commands are intercepted in the terminal and expanded before sending to Claude
- Includes a clean modal UI for creating/editing commands and a list view for management

## Features
✨ **Command Creation Modal** - Simple interface for creating custom shortcuts
📝 **Full Prompt Support** - Define complete prompts that expand when typing shortcuts
📁 **Reference Files** - Include workspace files in command prompts
🔗 **URL Support** - Add URLs for Claude to reference
💾 **Local Storage** - Commands persist across browser sessions
🎯 **Example Command** - Pre-loaded `/hn` command for fetching Hacker News posts

## Implementation Details
- Commands are stored in browser localStorage
- Terminal input handler intercepts shortcuts (e.g., `/hn`) and expands them
- Modal UI inspired by Dia Skills for intuitive command creation
- Support for editing and deleting existing commands

## Test plan
- [ ] Create a new slash command using the "➕ New Command" button
- [ ] Test the command by typing it in the terminal
- [ ] Edit an existing command using the edit button
- [ ] Delete a command and verify it is removed
- [ ] Verify commands persist after page refresh
- [ ] Test the pre-loaded `/hn` command

🤖 Generated with [Claude Code](https://claude.ai/code)