### PR TITLE
Production fixes and deployment improvements

### DIFF
--- a/Dockerfile.claude-env
+++ b/Dockerfile.claude-env
@@ -1,0 +1,26 @@
+FROM ubuntu:latest
+
+# Update and install dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    build-essential \
+    python3 \
+    python3-pip \
+    nodejs \
+    npm
+
+# Install Claude Code CLI globally
+RUN npm install -g @anthropic-ai/claude-code
+
+# Create workspace directory
+RUN mkdir -p /workspace
+
+# Set working directory
+WORKDIR /workspace
+
+# Set up environment variable for API key
+ENV ANTHROPIC_API_KEY=""
+
+# Default command
+CMD ["/bin/bash"]

--- a/client/src/contexts/WebSocketContext.tsx
+++ b/client/src/contexts/WebSocketContext.tsx
@@ -74,7 +74,10 @@ export const WebSocketProvider: React.FC<{ children: React.ReactNode }> = ({ chi
           throw new Error('No authentication token found');
         }
 
-        const ws = new WebSocket(`ws://localhost:${configRes.wsPort}`);
+        const wsUrl = process.env.NODE_ENV === 'production' 
+          ? `wss://${window.location.host}` 
+          : `ws://localhost:${configRes.wsPort}`;
+        const ws = new WebSocket(wsUrl);
         wsRef.current = ws;
 
         ws.onopen = () => {

--- a/docs/deploy-digitalocean.md
+++ b/docs/deploy-digitalocean.md
@@ -101,16 +101,11 @@ Copy and paste these commands one by one:
 
 1. **Build the Claude environment image:**
    ```bash
-   cd /opt
-   git clone https://github.com/bentossell/claude-docker-setup.git
-   cd claude-docker-setup
-   docker build -t claude-env .
-   ```
-
-2. **Go back to the main project:**
-   ```bash
    cd /opt/open-ODE
+   docker build -f Dockerfile.claude-env -t claude-env .
    ```
+   
+   This builds the Claude Code environment using the official `@anthropic-ai/claude-code` package.
 
 ## Step 7: Update WebSocket Configuration
 

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -1,0 +1,69 @@
+# Production Deployment Updates
+
+This document covers the production fixes and updates made during the initial deployment to DigitalOcean.
+
+## Changes Made
+
+### 1. Claude Environment Docker Image
+
+Created `Dockerfile.claude-env` to build the Claude Code environment:
+- Uses Ubuntu base image
+- Installs Node.js and npm
+- Installs the official Claude Code CLI: `@anthropic-ai/claude-code`
+- Sets up workspace directory
+
+Build command:
+```bash
+docker build -f Dockerfile.claude-env -t claude-env .
+```
+
+### 2. WebSocket Configuration for Production
+
+Updated `client/src/contexts/WebSocketContext.tsx` to automatically use:
+- `wss://` protocol with the current domain in production
+- `ws://localhost:8081` in development
+
+This allows the WebSocket to work through Caddy's SSL proxy without hardcoding URLs.
+
+### 3. Claude Command Path
+
+Fixed the Claude command path in `server.js`:
+- Changed from `/root/.npm-global/bin/claude` to just `claude`
+- The Claude Code CLI is now in PATH after global npm install
+
+### 4. Environment Variables
+
+Production requires these client-side environment variables in `client/.env`:
+```
+REACT_APP_SUPABASE_URL=https://your-project.supabase.co
+REACT_APP_SUPABASE_ANON_KEY=your-anon-key
+```
+
+Server-side `.env`:
+```
+SUPABASE_JWT_SECRET=your-jwt-secret
+ANTHROPIC_API_KEY=your-api-key
+SESSION_SECRET=random-string
+```
+
+## Deployment Architecture
+
+```
+Internet → Cloudflare DNS → DigitalOcean Droplet
+                                    ↓
+                              Caddy (SSL/Proxy)
+                              ↙            ↘
+                        Port 3000      Port 8081
+                        (HTTP API)    (WebSocket)
+                            ↓              ↓
+                      Docker Container (App)
+                            ↓
+                    Docker-in-Docker (Claude Sessions)
+```
+
+## Key Learnings
+
+1. **NPM Package Names**: The Claude Code CLI is `@anthropic-ai/claude-code`, not `claude-code`
+2. **WebSocket Proxying**: Use Caddy to handle SSL, don't connect directly to WebSocket port
+3. **Environment Variables**: React apps need `REACT_APP_` prefix for env vars
+4. **Docker PATH**: Global npm installs are available in PATH, no need for full paths

--- a/server.js
+++ b/server.js
@@ -173,7 +173,7 @@ class ClaudeSession {
         'exec',
         '-it',
         containerId,
-        '/root/.npm-global/bin/claude'
+        'claude'
       ], {
         name: 'xterm-color',
         cols: 80,


### PR DESCRIPTION
## Summary
- Fixed Claude Code CLI installation and command path
- Updated WebSocket configuration for production SSL
- Added comprehensive deployment documentation

## Changes
1. **Dockerfile.claude-env**: Proper Claude Code environment with `@anthropic-ai/claude-code`
2. **WebSocket URL**: Automatically uses `wss://` in production
3. **Command Path**: Fixed to use `claude` instead of full path
4. **Documentation**: Added production deployment notes and updated guides

## Testing
- ✅ Deployed and tested on https://openode.ai
- ✅ WebSocket connects through SSL
- ✅ Claude Code sessions start successfully
- ✅ Authentication works with Supabase

## Deployment Notes
These changes are critical for anyone deploying to production. The deployment guide now includes all the fixes we discovered during the initial deployment.