### PR TITLE
Add Tailwind and placeholder UI

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,6 +18,7 @@
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "dotenv": "^17.2.1",
+        "lucide-react": "^0.525.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-scripts": "5.0.1",
@@ -26,6 +27,11 @@
         "xterm": "^5.3.0",
         "xterm-addon-fit": "^0.8.0",
         "xterm-addon-web-links": "^0.9.0"
+      },
+      "devDependencies": {
+        "autoprefixer": "^10.4.21",
+        "postcss": "^8.5.6",
+        "tailwindcss": "^4.1.11"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -11409,6 +11415,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.525.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
+      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -14191,6 +14206,55 @@
         "node": ">=10"
       }
     },
+    "node_modules/react-scripts/node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/react-scripts/node_modules/tailwindcss": {
+      "version": "3.4.17",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
+      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.6",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -16057,53 +16121,11 @@
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
-      "version": "3.4.17",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
-      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
-      "license": "MIT",
-      "dependencies": {
-        "@alloc/quick-lru": "^5.2.0",
-        "arg": "^5.0.2",
-        "chokidar": "^3.6.0",
-        "didyoumean": "^1.2.2",
-        "dlv": "^1.1.3",
-        "fast-glob": "^3.3.2",
-        "glob-parent": "^6.0.2",
-        "is-glob": "^4.0.3",
-        "jiti": "^1.21.6",
-        "lilconfig": "^3.1.3",
-        "micromatch": "^4.0.8",
-        "normalize-path": "^3.0.0",
-        "object-hash": "^3.0.0",
-        "picocolors": "^1.1.1",
-        "postcss": "^8.4.47",
-        "postcss-import": "^15.1.0",
-        "postcss-js": "^4.0.1",
-        "postcss-load-config": "^4.0.2",
-        "postcss-nested": "^6.2.0",
-        "postcss-selector-parser": "^6.1.2",
-        "resolve": "^1.22.8",
-        "sucrase": "^3.35.0"
-      },
-      "bin": {
-        "tailwind": "lib/cli.js",
-        "tailwindcss": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/lilconfig": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antonk52"
-      }
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
+      "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.2.2",

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "dotenv": "^17.2.1",
+    "lucide-react": "^0.525.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-scripts": "5.0.1",
@@ -45,5 +46,10 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^4.1.11"
   }
 }

--- a/client/postcss.config.js
+++ b/client/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders dashboard text', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const el = screen.getByText(/dashboard/i);
+  expect(el).toBeInTheDocument();
 });

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,14 +1,9 @@
 import React from 'react';
-import TerminalApp from './TerminalApp';
-import { WebSocketProvider } from './contexts/WebSocketContext';
-import './App.css';
+import './index.css';
+import OpenInterface from './OpenInterface';
 
 function App() {
-  return (
-    <WebSocketProvider>
-      <TerminalApp />
-    </WebSocketProvider>
-  );
+  return <OpenInterface />;
 }
 
 export default App;

--- a/client/src/OpenInterface.tsx
+++ b/client/src/OpenInterface.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Home, Plus, FolderPlus, Archive, MessageSquare, Settings, PanelRight } from 'lucide-react';
+
+export default function OpenInterface() {
+  return (
+    <div className="h-screen flex overflow-hidden bg-gray-100">
+      <aside className="w-60 bg-white border-r flex flex-col">
+        <div className="p-4 flex items-center gap-2 border-b">
+          <Home className="w-4 h-4" />
+          <span className="text-sm font-medium">Dashboard</span>
+        </div>
+        <div className="flex-1 overflow-y-auto p-2 space-y-2">
+          <div className="text-xs uppercase text-gray-500 px-2">Workspaces</div>
+          <div className="space-y-1">
+            <div className="px-2 py-1 rounded hover:bg-gray-100 cursor-pointer">web-claude-interface</div>
+            <div className="px-2 py-1 rounded hover:bg-gray-100 cursor-pointer">slash-commands-feature</div>
+            <div className="px-2 py-1 rounded hover:bg-gray-100 cursor-pointer bg-gray-200">claude-web-terminal</div>
+          </div>
+          <button className="flex items-center gap-1 text-sm text-gray-600 mt-2 hover:text-black">
+            <Plus className="w-4 h-4" /> New workspace
+          </button>
+        </div>
+        <div className="p-4 flex items-center justify-between border-t text-gray-500 text-sm">
+          <button className="flex items-center gap-2 hover:text-black">
+            <FolderPlus className="w-4 h-4" /> Add repository
+          </button>
+          <div className="flex items-center gap-4">
+            <Archive className="w-4 h-4 hover:text-black" />
+            <MessageSquare className="w-4 h-4 hover:text-black" />
+            <Settings className="w-4 h-4 hover:text-black" />
+          </div>
+        </div>
+      </aside>
+      <main className="flex-1 flex flex-col overflow-hidden">
+        <header className="flex items-center justify-between bg-white p-4 border-b">
+          <div className="flex items-center gap-2 text-sm">
+            <span className="font-medium">claude-web-terminal</span>
+          </div>
+          <div className="flex items-center gap-2 text-gray-500">
+            <button className="hover:text-black"><PanelRight className="w-4 h-4" /></button>
+          </div>
+        </header>
+        <div className="flex-1 flex overflow-hidden">
+          <div className="flex-1 overflow-y-auto p-4 space-y-4 text-sm">
+            <div>You're in the <strong>Douala</strong> workspace. This is a fresh copy of your codebase.</div>
+            <div>You're on a new branch <strong>claude-web-terminal</strong>. Once you start working, I'll rename the branch to be more descriptive.</div>
+            <div>What would you like me to do?</div>
+            <div className="flex justify-end"><div className="bg-yellow-100 text-yellow-800 p-2 rounded">hi</div></div>
+            <div>I'll rename the branch to something more descriptive. Based on the CLAUDE.md file, this project is building a web-accessible terminal interface for Claude Code. Let me rename the branch accordingly.</div>
+            <div className="text-gray-500 italic">[placeholder for more conversation]</div>
+          </div>
+          <aside className="w-64 border-l flex flex-col">
+            <div className="flex-1 flex items-center justify-center text-gray-500">No todos yet</div>
+            <div className="border-t p-4 text-sm hover:bg-gray-100 cursor-pointer">Terminal</div>
+          </aside>
+        </div>
+        <div className="p-4 border-t bg-white">
+          <textarea className="w-full border rounded p-2 h-24" placeholder="Ask Claude anything..."></textarea>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,13 +1,7 @@
-body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+body {
+  @apply m-0 font-sans antialiased;
 }

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./src/**/*.{js,jsx,ts,tsx}"
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add Tailwind CSS configuration and postcss
- add a simplified placeholder UI based on provided HTML
- swap App to render the new interface
- update the default test

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68839590bcac8327941bd2e051f1096b