### PR TITLE
Fix deprecated GitHub Actions v3 to v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,10 +21,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
           
@@ -42,7 +42,7 @@ jobs:
         continue-on-error: true
         
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: production-build
           path: |
@@ -58,7 +58,7 @@ jobs:
     environment: development
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: production-build
           
@@ -74,7 +74,7 @@ jobs:
     environment: staging
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: production-build
           
@@ -90,7 +90,7 @@ jobs:
     environment: production
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: production-build
           


### PR DESCRIPTION
## Summary
This PR fixes the deprecated GitHub Actions warnings by updating all actions to v4.

## Error Fixed
> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

## Changes
Updated all GitHub Actions in `.github/workflows/deploy.yml`:
- `actions/checkout@v3` → `v4`
- `actions/setup-node@v3` → `v4`
- `actions/upload-artifact@v3` → `v4`
- `actions/download-artifact@v3` → `v4`

## Impact
This will allow the deployment workflows to run without deprecation errors.

🤖 Generated with [Claude Code](https://claude.ai/code)