### PR TITLE
Fix SSH authentication for Digital Ocean deployment

### DIFF
--- a/.github/workflows/deploy-digitalocean-alt.yml
+++ b/.github/workflows/deploy-digitalocean-alt.yml
@@ -1,14 +1,9 @@
-name: Deploy to DigitalOcean (Disabled - Use Alternative)
+name: Deploy to DigitalOcean (Alternative)
 
 on:
+  push:
+    branches: [ main ]
   workflow_dispatch:
-    inputs:
-      confirm:
-        description: 'This workflow has authentication issues. Use deploy-digitalocean-alt.yml instead'
-        required: true
-        type: choice
-        options:
-          - 'use-alternative-workflow'
 
 jobs:
   deploy:
@@ -18,15 +13,19 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    - name: Setup SSH Key
+      run: |
+        mkdir -p ~/.ssh
+        echo "${{ secrets.DO_SSH_KEY }}" > ~/.ssh/deploy_key
+        chmod 600 ~/.ssh/deploy_key
+        ssh-keyscan -H ${{ secrets.DO_HOST }} >> ~/.ssh/known_hosts
+
     - name: Deploy to DigitalOcean Droplet
-      uses: appleboy/ssh-action@v1.0.3
-      with:
-        host: ${{ secrets.DO_HOST }}
-        username: ${{ secrets.DO_USERNAME }}
-        key: ${{ secrets.DO_SSH_KEY }}
-        port: 22
-        script_stop: true
-        script: |
+      env:
+        DO_HOST: ${{ secrets.DO_HOST }}
+        DO_USERNAME: ${{ secrets.DO_USERNAME }}
+      run: |
+        ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no $DO_USERNAME@$DO_HOST << 'EOF'
           # Navigate to project directory
           cd /opt/open-ODE
           
@@ -62,3 +61,4 @@ jobs:
           
           # Verify deployment
           docker ps | grep openode-container
+        EOF


### PR DESCRIPTION
## Summary
This PR fixes the SSH authentication error in the Digital Ocean deployment workflow.

## Error Fixed
```
2025/07/25 20:44:55 ssh.ParsePrivateKey: ssh: no key found
ssh: handshake failed: ssh: unable to authenticate
```

## Solution
Created an alternative deployment workflow that properly handles OpenSSH format keys:

1. **New workflow**: `deploy-digitalocean-alt.yml`
   - Uses native SSH commands instead of appleboy/ssh-action
   - Properly sets up SSH key with correct permissions (600)
   - Adds host to known_hosts using ssh-keyscan
   - Uses heredoc for clean command execution

2. **Disabled failing workflow**: Updated `deploy-digitalocean.yml`
   - Removed automatic trigger on push to main
   - Added warning message about using the alternative workflow

## Why This Works
The original appleboy/ssh-action@v1.0.0 has issues parsing OpenSSH format ed25519 keys. The new approach uses standard SSH commands that handle all key formats correctly.

## Testing
After merging, the deployment will automatically trigger using the new workflow when pushing to main.

🤖 Generated with [Claude Code](https://claude.ai/code)