### PR TITLE
Fix Digital Ocean deployment with shimataro SSH action

### DIFF
--- a/.github/workflows/deploy-digitalocean-simple.yml
+++ b/.github/workflows/deploy-digitalocean-simple.yml
@@ -1,4 +1,4 @@
-name: Deploy to DigitalOcean (Alternative)
+name: Deploy to DigitalOcean (Simple)
 
 on:
   push:
@@ -13,40 +13,48 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Setup SSH Key
-      run: |
-        mkdir -p ~/.ssh
-        echo "${{ secrets.DO_SSH_KEY }}" > ~/.ssh/deploy_key
-        chmod 600 ~/.ssh/deploy_key
-        ssh-keyscan -H ${{ secrets.DO_HOST }} >> ~/.ssh/known_hosts
+    - name: Install SSH Key
+      uses: shimataro/ssh-key-action@v2
+      with:
+        key: ${{ secrets.DO_SSH_KEY }}
+        known_hosts: ${{ secrets.DO_HOST }}
 
-    - name: Deploy to DigitalOcean Droplet
-      env:
-        DO_HOST: ${{ secrets.DO_HOST }}
-        DO_USERNAME: ${{ secrets.DO_USERNAME }}
+    - name: Add Known Hosts
+      run: ssh-keyscan -H ${{ secrets.DO_HOST }} >> ~/.ssh/known_hosts
+
+    - name: Deploy to DigitalOcean
       run: |
-        ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no $DO_USERNAME@$DO_HOST << 'EOF'
+        ssh ${{ secrets.DO_USERNAME }}@${{ secrets.DO_HOST }} 'bash -s' << 'EOF'
+          set -e
+          echo "Starting deployment..."
+          
           # Navigate to project directory
           cd /opt/open-ODE
           
           # Pull latest changes
+          echo "Pulling latest changes..."
           git pull origin main
           
           # Install dependencies
+          echo "Installing dependencies..."
           npm ci
           cd client && npm ci && cd ..
           
           # Build the client
+          echo "Building client..."
           cd client && npm run build && cd ..
           
           # Build Docker image
+          echo "Building Docker image..."
           docker build -t openode-app .
           
           # Stop existing container
+          echo "Stopping existing container..."
           docker stop openode-container || true
           docker rm openode-container || true
           
           # Run new container
+          echo "Starting new container..."
           docker run -d \
             --name openode-container \
             --restart unless-stopped \
@@ -57,8 +65,12 @@ jobs:
             openode-app
           
           # Clean up old images
+          echo "Cleaning up..."
           docker image prune -f
           
           # Verify deployment
+          echo "Verifying deployment..."
           docker ps | grep openode-container
+          
+          echo "Deployment complete!"
         EOF

--- a/.github/workflows/deploy-digitalocean.yml
+++ b/.github/workflows/deploy-digitalocean.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       confirm:
-        description: 'This workflow has authentication issues. Use deploy-digitalocean-alt.yml instead'
+        description: 'This workflow has authentication issues. Use deploy-digitalocean-simple.yml instead'
         required: true
         type: choice
         options:


### PR DESCRIPTION
## Summary
Final fix for the SSH authentication issues in Digital Ocean deployment.

## Previous Errors
- ssh.ParsePrivateKey: ssh: no key found - Original workflow couldn't parse OpenSSH keys
- Load key: error in libcrypto - Alternative workflow had crypto library issues

## Solution
Using shimataro/ssh-key-action@v2 which:
- Properly handles ed25519 keys in OpenSSH format
- Is battle-tested and widely used
- Handles all SSH key formats correctly

## Changes
- Created deploy-digitalocean-simple.yml with shimataro action
- Removed failing deploy-digitalocean-alt.yml
- Updated disabled workflow to reference the new simple workflow

## Testing
This workflow will trigger automatically on push to main branch after merging.