### PR TITLE
Fix SSH ed25519 key authentication in deployment

### DIFF
--- a/.github/workflows/deploy-digitalocean-simple.yml
+++ b/.github/workflows/deploy-digitalocean-simple.yml
@@ -13,18 +13,16 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Install SSH Key
-      uses: shimataro/ssh-key-action@v2
-      with:
-        key: ${{ secrets.DO_SSH_KEY }}
-        known_hosts: ${{ secrets.DO_HOST }}
-
-    - name: Add Known Hosts
-      run: ssh-keyscan -H ${{ secrets.DO_HOST }} >> ~/.ssh/known_hosts
+    - name: Setup SSH Key
+      run: |
+        mkdir -p ~/.ssh
+        echo "${{ secrets.DO_SSH_KEY }}" > ~/.ssh/id_ed25519
+        chmod 600 ~/.ssh/id_ed25519
+        ssh-keyscan -H ${{ secrets.DO_HOST }} >> ~/.ssh/known_hosts
 
     - name: Deploy to DigitalOcean
       run: |
-        ssh ${{ secrets.DO_USERNAME }}@${{ secrets.DO_HOST }} 'bash -s' << 'EOF'
+        ssh -i ~/.ssh/id_ed25519 -o StrictHostKeyChecking=no ${{ secrets.DO_USERNAME }}@${{ secrets.DO_HOST }} 'bash -s' << 'EOF'
           set -e
           echo "Starting deployment..."
           


### PR DESCRIPTION
## Summary
Fixes the SSH authentication error by explicitly handling ed25519 keys.

## Problem
The shimataro SSH action was defaulting to looking for id_rsa, but we're using an ed25519 key. This caused:
- Load key /home/runner/.ssh/id_rsa: error in libcrypto
- Permission denied (publickey)

## Solution
- Save the SSH key explicitly as ~/.ssh/id_ed25519
- Use ssh -i flag to specify the exact key file
- Add StrictHostKeyChecking=no to avoid host verification issues

## Manual Deployment Commands (for immediate use)
Run these in your Digital Ocean droplet console:

```bash
cd /opt/open-ODE
git pull origin main
npm ci
cd client && npm ci && npm run build && cd ..
docker build -t openode-app .
docker stop openode-container || true
docker rm openode-container || true
docker run -d --name openode-container --restart unless-stopped -p 3000:3000 -p 8081:8081 -v /var/run/docker.sock:/var/run/docker.sock --env-file .env openode-app
docker image prune -f
docker ps  < /dev/null |  grep openode-container
```

## Testing
This workflow will trigger on push to main after merging.