### PR TITLE
Fix WebSocket double connection and authentication issues

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,29 +1,13 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import './index.css';
 import { OpenTerminal } from './OpenTerminal';
 import { WebSocketProvider } from './contexts/WebSocketContext';
-import { supabase } from './lib/supabase';
+import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { Auth } from './components/Auth';
 import { ErrorBoundary } from './components/ErrorBoundary';
 
-function App() {
-  const [session, setSession] = useState<any>(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    // Check for existing session
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      setSession(session);
-      setLoading(false);
-    });
-
-    // Listen for auth changes
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
-      setSession(session);
-    });
-
-    return () => subscription.unsubscribe();
-  }, []);
+function AppContent() {
+  const { user, loading } = useAuth();
 
   if (loading) {
     return (
@@ -33,11 +17,11 @@ function App() {
     );
   }
 
-  if (!session) {
+  if (!user) {
     return (
       <ErrorBoundary>
         <Auth onAuthenticated={() => {
-          // Auth state change will be handled by the listener
+          // Auth state change will be handled by AuthContext
         }} />
       </ErrorBoundary>
     );
@@ -49,6 +33,14 @@ function App() {
         <OpenTerminal />
       </WebSocketProvider>
     </ErrorBoundary>
+  );
+}
+
+function App() {
+  return (
+    <AuthProvider>
+      <AppContent />
+    </AuthProvider>
   );
 }
 


### PR DESCRIPTION
Fixes #22

Consolidates duplicate authentication systems and removes automatic WebSocket connections that were causing double connection attempts and Supabase refresh token conflicts.

## Changes
- Consolidate authentication: App.tsx now uses AuthContext instead of duplicate session management
- Remove auto-connect: WebSocket connections are now manual via "Start Session" button
- Improve connection logic: Better handling of concurrent connection attempts
- Fix production WebSocket URLs: Proper handling of domain-based vs port-based connections
- Use AuthContext consistently: OpenTerminal now uses AuthContext for signOut

Generated with [Claude Code](https://claude.ai/code)