### PR TITLE
Fix mobile start session button

### DIFF
--- a/client/src/ModernTerminal.tsx
+++ b/client/src/ModernTerminal.tsx
@@ -199,11 +199,12 @@ const ModernTerminal: React.FC = () => {
         <div className="p-4">
           <div className="mb-6">
             <h1 className="text-xl font-bold mb-2">OpenODE</h1>
-            <Button 
-              variant="outline" 
-              size="sm" 
+            <Button
+              variant="outline"
+              size="sm"
               className="w-full justify-start gap-2"
               onClick={startSession}
+              onTouchStart={startSession}
               disabled={sessionStarted}
             >
               <Plus className="h-4 w-4" />

--- a/client/src/OpenTerminal.tsx
+++ b/client/src/OpenTerminal.tsx
@@ -285,6 +285,7 @@ export const OpenTerminal: React.FC = () => {
             <span className="text-lg font-semibold text-gray-900">Terminal Session</span>
             <button
               onClick={startSession}
+              onTouchStart={startSession}
               disabled={sessionStarted}
               className={`flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-colors ${
                 sessionStarted

--- a/client/src/TerminalApp.tsx
+++ b/client/src/TerminalApp.tsx
@@ -243,8 +243,9 @@ function TerminalApp() {
       </header>
       
       <div className="controls">
-        <button 
-          onClick={startSession} 
+        <button
+          onClick={startSession}
+          onTouchStart={startSession}
           disabled={isStarting || status === 'session-started'}
           className="start-button"
         >

--- a/client/src/XTerminal.tsx
+++ b/client/src/XTerminal.tsx
@@ -123,11 +123,12 @@ export const XTerminal: React.FC = () => {
         <div className="p-4">
           <div className="mb-6">
             <h1 className="text-xl font-bold mb-2">OpenODE</h1>
-            <Button 
-              variant="outline" 
-              size="sm" 
+            <Button
+              variant="outline"
+              size="sm"
               className="w-full justify-start gap-2"
               onClick={startSession}
+              onTouchStart={startSession}
               disabled={sessionStarted}
             >
               <Plus className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- add `onTouchStart` handler to Start Session buttons to support touch devices

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module '@/lib/utils')*

------
https://chatgpt.com/codex/tasks/task_e_68854a7ce5cc832791585af48a8a554f